### PR TITLE
chore: enable strict index checking

### DIFF
--- a/packages/api-server/src/mock/api.ts
+++ b/packages/api-server/src/mock/api.ts
@@ -184,7 +184,13 @@ export const readSerialConfig = (): Promise<typeof mockDevice["serial"]> =>
   delay(50).then(() => mockDevice.serial);
 
 export const readUID = (port: string): Promise<string> =>
-  delay(30).then(() => ids[port]);
+  delay(30).then(() => {
+    const id = ids[port];
+    if (id) {
+      return id;
+    }
+    throw new Error("Port does not exist");
+  });
 
 export const writeReboot = (port: string): Promise<boolean> =>
   delay(100).then(() => true);

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -1,3 +1,18 @@
 // eslint-disable-next-line import/prefer-default-export
 export const bitCheck = (num: number, bit: number): boolean =>
   (num >> bit) % 2 !== 0;
+
+type TupleOf<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : _TupleOf<T, N, []>
+  : never;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+type _TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N
+  ? R
+  : _TupleOf<T, N, [T, ...R]>;
+
+export const isTupleOf = <T, N extends number>(
+  list: T[],
+  length: N
+): list is TupleOf<T, N> => list.length === length;

--- a/packages/configurator/src/components/ChannelsList/ChannelsList.tsx
+++ b/packages/configurator/src/components/ChannelsList/ChannelsList.tsx
@@ -31,12 +31,8 @@ export type ChannelsListProps = {
 };
 
 const ChannelsList: React.FC<ChannelsListProps> = ({ channels, disabled }) => {
-  const getChannelName = (number: number): string => {
-    if (number >= CHANNEL_NAMES.length) {
-      return `AUX ${number - CHANNEL_NAMES.length + 1}`;
-    }
-    return CHANNEL_NAMES[number];
-  };
+  const getChannelName = (number: number): string =>
+    CHANNEL_NAMES[number] ?? `AUX ${number - CHANNEL_NAMES.length + 1}`;
 
   return (
     <Wrapper>

--- a/packages/configurator/src/hooks/useSimulatedAttitude.ts
+++ b/packages/configurator/src/hooks/useSimulatedAttitude.ts
@@ -99,7 +99,7 @@ export default (
             (roll +
               delta *
                 calcRate(
-                  channels[0],
+                  channels[0] ?? 0,
                   tuning.rollRate,
                   tuning.rcRate,
                   tuning.rcExpo,
@@ -113,7 +113,7 @@ export default (
             (pitch +
               delta *
                 calcRate(
-                  channels[1],
+                  channels[1] ?? 0,
                   tuning.pitchRate,
                   tuning.rcPitchRate,
                   tuning.rcPitchExpo,
@@ -127,7 +127,7 @@ export default (
             (heading +
               delta *
                 calcRate(
-                  channels[2],
+                  channels[2] ?? 0,
                   tuning.yawRate,
                   tuning.rcYawRate,
                   tuning.rcYawExpo,

--- a/packages/configurator/src/managers/NavigationManager.tsx
+++ b/packages/configurator/src/managers/NavigationManager.tsx
@@ -242,7 +242,7 @@ const NavigationManager: React.FC = () => {
     if (!loading && !links.find((link) => link.id === selectedTab)) {
       selectTab({
         variables: {
-          tabId: links[0].id,
+          tabId: links[0]!.id,
         },
       });
     }

--- a/packages/msp/src/connection.ts
+++ b/packages/msp/src/connection.ts
@@ -30,7 +30,7 @@ const initialiseBindings = (): void => {
   SerialPort.Binding = Binding;
 };
 
-const log = debug("connection");
+const log = debug("msp:connection");
 
 const connectionsMap: Record<string, Connection | undefined> = {};
 
@@ -81,7 +81,7 @@ export const execute = async (
             return;
           }
           log(
-            `${request.toJSON().data} response: ${
+            `request: ${request.toJSON().data}, response: ${
               Buffer.from(message.data).toJSON().data
             }, byteLength: ${message.data.byteLength}`
           );

--- a/packages/msp/src/encoders.ts
+++ b/packages/msp/src/encoders.ts
@@ -19,9 +19,9 @@ export const encodeMessageV1 = (code: number, data?: Buffer): Buffer => {
     checksum = bufView[3] ^ bufView[4];
 
     for (let i = 0; i < data.length; i += 1) {
-      bufView[i + 5] = data[i];
+      bufView[i + 5] = data[i]!;
 
-      checksum ^= bufView[i + 5];
+      checksum ^= bufView[i + 5]!;
     }
 
     bufView[5 + data.length] = checksum;
@@ -54,7 +54,7 @@ export const encodeMessageV2 = (code: number, data?: Buffer): Buffer => {
   bufView[6] = dataLength & 0xff;
   bufView[7] = (dataLength >> 8) & 0xff;
   for (let i = 0; i < dataLength; i += 1) {
-    bufView[8 + i] = data![i];
+    bufView[8 + i] = data![i]!;
   }
   bufView[bufferSize - 1] = crc8DvbS2Data(bufView, 3, bufferSize - 1);
   return Buffer.from(bufferOut);

--- a/packages/msp/src/utils.ts
+++ b/packages/msp/src/utils.ts
@@ -16,9 +16,7 @@ export const crc8DvbS2Data = (
   start: number,
   end: number
 ): number => {
-  let crc = 0;
-  for (let i = start; i < end; i += 1) {
-    crc = crc8DvbS2(crc, data[i]);
-  }
-  return crc;
+  return data
+    .slice(start, end)
+    .reduce((computed, byte) => crc8DvbS2(computed, byte), 0);
 };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "declaration": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
Typescript 4.1 introduced the `noUncheckedIndexedAccess` which means anywhere where an explicit index is used on a generic array or object the result could be undefined